### PR TITLE
Prepare for 2.0.0 development

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ tasks.withType(JavaCompile) {
 buildscript {
     ext.repository_name = 'GitHubPackages'
     ext.repository_url = 'https://maven.pkg.github.com/lisb/fieldname-constant-annotation'
-		ext.package_group_id = 'com.lisb.fieldname-constant-annotation'
-		ext.package_version = '1.0.1'
+    ext.package_group_id = 'com.lisb.fieldname-constant-annotation'
+    ext.package_version = '2.0.0-SNAPSHOT'
     ext.localProps = new Properties()
     localProps.load(rootProject.file('local.properties').newDataInputStream())
 


### PR DESCRIPTION
[direct-13713 : fieldname-constant-annotation のKSP移行](https://lisb.myjetbrains.com/youtrack/issue/direct-13713) の対応を行うためバージョンを `2.0.0-SNAPSHOT` へ更新